### PR TITLE
fix(PomodoroTimer): Fix displayed time

### DIFF
--- a/src/components/pomodoro-timer/TimerInner.js
+++ b/src/components/pomodoro-timer/TimerInner.js
@@ -20,9 +20,9 @@ export default class TimerInner extends Component {
 
   remainTime(): string {
     const { remainTimeInMillis } = this.props;
-    const s = ((remainTimeInMillis < 0) ? 0 : remainTimeInMillis) / 1000;
+    const s = Math.round(((remainTimeInMillis < 0) ? 0 : remainTimeInMillis) / 1000);
+    const sec = s % 60;
     const min = Math.floor(s / 60);
-    const sec = Math.round(s) % 60;
     return `${min}:${(`00${sec}`).slice(-2)}`;
   }
 


### PR DESCRIPTION
The timer sometimes display invalid time, such as 24:00 -> 24:59